### PR TITLE
Update Preference from 1.0.0 to 1.1.0

### DIFF
--- a/preference/build.gradle
+++ b/preference/build.gradle
@@ -24,6 +24,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.preference:preference:1.0.0'
+    implementation 'androidx.preference:preference:1.1.0'
     compileOnly 'com.bluelinelabs:conductor:2.1.5'
 }

--- a/preference/src/main/java/androidx/preference/MultiSelectListPreferenceDialogController.java
+++ b/preference/src/main/java/androidx/preference/MultiSelectListPreferenceDialogController.java
@@ -20,7 +20,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.preference.internal.AbstractMultiSelectListPreference;
+import androidx.preference.MultiSelectListPreference;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -59,7 +59,7 @@ public class MultiSelectListPreferenceDialogController extends PreferenceDialogC
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState == null) {
-            final AbstractMultiSelectListPreference preference = getListPreference();
+            final MultiSelectListPreference preference = getListPreference();
 
             if (preference.getEntries() == null || preference.getEntryValues() == null) {
                 throw new IllegalStateException(
@@ -94,8 +94,8 @@ public class MultiSelectListPreferenceDialogController extends PreferenceDialogC
         mEntryValues = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRY_VALUES);
     }
 
-    private AbstractMultiSelectListPreference getListPreference() {
-        return (AbstractMultiSelectListPreference) getPreference();
+    private MultiSelectListPreference getListPreference() {
+        return (MultiSelectListPreference) getPreference();
     }
 
     @Override
@@ -124,7 +124,7 @@ public class MultiSelectListPreferenceDialogController extends PreferenceDialogC
 
     @Override
     public void onDialogClosed(boolean positiveResult) {
-        final AbstractMultiSelectListPreference preference = getListPreference();
+        final MultiSelectListPreference preference = getListPreference();
         if (positiveResult && mPreferenceChanged) {
             final Set<String> values = mNewValues;
             if (preference.callChangeListener(values)) {

--- a/preference/src/main/java/androidx/preference/PreferenceController.java
+++ b/preference/src/main/java/androidx/preference/PreferenceController.java
@@ -35,7 +35,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.XmlRes;
 import androidx.fragment.app.Fragment;
-import androidx.preference.internal.AbstractMultiSelectListPreference;
+import androidx.preference.MultiSelectListPreference;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.bluelinelabs.conductor.RestoreViewOnCreateController;
@@ -612,7 +612,7 @@ public abstract class PreferenceController extends RestoreViewOnCreateController
             f = EditTextPreferenceDialogController.newInstance(preference.getKey());
         } else if (preference instanceof ListPreference) {
             f = ListPreferenceDialogController.newInstance(preference.getKey());
-        } else if (preference instanceof AbstractMultiSelectListPreference) {
+        } else if (preference instanceof MultiSelectListPreference) {
             f = MultiSelectListPreferenceDialogController.newInstance(preference.getKey());
         } else {
             throw new IllegalArgumentException("Tried to display dialog for unknown " +


### PR DESCRIPTION
In `androidx.preference:preference:1.1.0` the class `AbstractMultiSelectListPreference` is no longer available.

This library has `androidx.preference:preference:1.0.0` and uses the `AbstractMultiSelectListPreference` class which will cause any projects that add `v1.1.0` as a dependency to crash.

If added in gradle:
```
implementation 'com.github.inorichi:conductor-support-preference:78e2344' <-- uses 1.0.0
implementation 'androidx.preference:preference:1.1.0'
```
Gradle will take `v1.1.0` as priority & `AbstractMultiSelectListPreference` is no longer able to be referenced.
